### PR TITLE
Remove Extra Forward Slash

### DIFF
--- a/assets/scripts/config.js
+++ b/assets/scripts/config.js
@@ -2,7 +2,7 @@
 
 let apiUrl
 const apiUrls = {
-  production: 'https://pure-savannah-85782.herokuapp.com/',
+  production: 'https://pure-savannah-85782.herokuapp.com',
   development: 'http://localhost:4741'
 }
 


### PR DESCRIPTION
Removed the forward slash at the end of the production url because it was causing my api calls to have two forward slashes in the url it was trying to reach.